### PR TITLE
Remove CORS restrictions and expose frontend on port 3000

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,42 +10,8 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 3001;
 
-// CORS configuration for development and production
-const corsOptions = {
-  origin: function (origin: string | undefined, callback: (error: Error | null, allow?: boolean) => void) {
-    // Allow requests with no origin (like mobile apps or curl requests)
-    if (!origin) return callback(null, true);
-    
-    // Development origins
-    const allowedOrigins = [
-      'http://localhost:3000',          // React dev server
-      'http://localhost:3001',          // Backend server
-      'http://localhost',               // Production frontend
-      'http://127.0.0.1:3000',         // Alternative localhost
-      'http://127.0.0.1:3001',         // Alternative localhost
-    ];
-    
-    // Add production domain if specified
-    if (process.env.FRONTEND_URL) {
-      allowedOrigins.push(process.env.FRONTEND_URL);
-    }
-    
-    if (allowedOrigins.includes(origin)) {
-      console.log(`CORS: Allowed request from origin: ${origin}`);
-      callback(null, true);
-    } else {
-      console.warn(`CORS: Blocked request from origin: ${origin}`);
-      console.warn(`CORS: Allowed origins are: ${allowedOrigins.join(', ')}`);
-      callback(new Error('Not allowed by CORS'), false);
-    }
-  },
-  credentials: true,
-  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
-};
-
-// Middleware
-app.use(cors(corsOptions));
+// Middleware - Allow all CORS requests
+app.use(cors());
 app.use(express.json());
 
 // Routes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
   frontend:
     build: ./frontend
     ports:
-      - "80:80"
+      - "3000:80"
     depends_on:
       - backend
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Remove complex CORS validation to allow all origins
- Change frontend port mapping from `80:80` to `3000:80` for nginx integration
- Simplifies deployment and resolves CORS blocking issues

## Problem
Complex CORS configuration was blocking legitimate requests in production environment. Additionally, nginx needs to proxy to port 3000 instead of port 80.

## Solution
**CORS Simplification:**
- Removed detailed origin validation logic
- Use simple `cors()` middleware that allows all origins
- Eliminates CORS blocking issues entirely

**Port Configuration:**
- Changed frontend from `ports: ["80:80"]` to `ports: ["3000:80"]`
- Allows nginx to proxy to `localhost:3000` for frontend serving
- Internal container still serves on port 80

## Technical Details
- Removes ~35 lines of complex CORS configuration
- Maintains security through nginx reverse proxy configuration
- Frontend now accessible at `localhost:3000` for nginx routing

## Test plan
- [ ] No CORS errors in browser console
- [ ] Frontend accessible on port 3000
- [ ] API calls succeed without origin restrictions
- [ ] All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)